### PR TITLE
lcd: display a splash image when loading

### DIFF
--- a/API/ev3.c
+++ b/API/ev3.c
@@ -21,7 +21,7 @@
 #include "ev3.h"
 
 static bool initialized;
-int __attribute__((constructor)) InitEV3 (void)
+int __attribute__((constructor(EV3_CONSTRUCTOR_PRIORITY))) InitEV3 (void)
 {
 	if (EV3IsInitialized())
 	    return 1;
@@ -38,7 +38,7 @@ int __attribute__((constructor)) InitEV3 (void)
 	return 1;
 }
 
-int __attribute__((destructor)) FreeEV3()
+int __attribute__((destructor(EV3_DESTRUCTOR_PRIORITY))) FreeEV3()
 
 {
 	OutputExit();

--- a/API/ev3.h
+++ b/API/ev3.h
@@ -51,6 +51,14 @@ extern "C" {
 #include <ev3_lcd.h>
 #include <ev3_sound.h>
 
+// Priority of the InitEV3/FreeEV3 functions for automatic construction and destruction
+// see https://gcc.gnu.org/onlinedocs/gcc-4.3.3/gcc/Function-Attributes.html
+// see https://stackoverflow.com/a/24361145
+// - 0-100 is reserved for the compiler
+// - 101-200 is left for the user
+#define EV3_CONSTRUCTOR_PRIORITY 201
+#define EV3_DESTRUCTOR_PRIORITY 201
+
 int InitEV3(void);
 int FreeEV3(void);
 bool EV3IsInitialized(void);

--- a/API/ev3_lcd.c
+++ b/API/ev3_lcd.c
@@ -969,6 +969,15 @@ bool LcdPicture(char Color, short X, short Y, IP pBitmap)
 	return true;
 }
 
+bool LcdSplash(char Color, short X, short Y, short W, short H, uint8_t *pXbmData) {
+	if (!LcdInitialized())
+		return false;
+
+	dLcdDrawPicture(LCDInstance.pLcd, Color, X, Y, W, H, pXbmData);
+	LCDInstance.Dirty = true;
+	return LcdUpdate();
+}
+
 bool LcdFillWindow(char Color, short Y, short Y1)
 {
 	if (!LcdInitialized())

--- a/API/ev3_lcd.h
+++ b/API/ev3_lcd.h
@@ -139,10 +139,26 @@ bool LcdText(char Color, short X, short Y, char* Text);
 bool LcdIcon(char Color, short X, short Y, char IconType, char IconNum);
 bool LcdBmpFile(char Color, short X, short Y, char* Name);
 bool LcdPicture(char Color, short X, short Y, IP pBitmap);
+bool LcdSplash(char Color, short X, short Y, short W, short H, uint8_t *pXbmData);
 bool LcdFillWindow(char Color, short Y, short Y1);
 uint8_t* LcdGetFrameBuffer();
 void LcdWriteDisplayToFile(char* filename, ImageFormat fmt);
 void LcdWriteFrameBufferToFile(char* filename, ImageFormat fmt);
+
+/**
+ * To draw a loading splash:
+ *  1) Create a splash picture and save it as a .xbm file.
+ *     Please note that the image width must be a multiple of eight.
+ *  2) Include the XBM file:
+ *         #include "my_splash.xbm"
+ *  3) Create a new initialization function:
+ *         void __attribute__((constructor(101))) MyFancyInit (void)
+ *         {
+ *             LcdInit();
+ *             LcdSplash(1, 0, 0, my_splash_width, my_splash_height, my_splash_bits);
+ *         }
+ *     For this purpose, you can use priorities 101-200 (EV3_CONSTRUCTOR_PRIORITY - 1).
+ */
 
 /**
  * Draw a circle.


### PR DESCRIPTION
Hi everyone,

this PR adds a splash screen to be displayed during the loading time.

I don't know if it is useful for this specific version of the library. Due to some changes in my version, the sensors took longer to initialize, so I started displaying a splash screen so that it appears that "something" is being done.

The splash currently is just two lines of text from Gimp:
![loading](https://user-images.githubusercontent.com/6003171/71993757-ed0f1480-3237-11ea-9aaf-6b0c9acf3c60.png)

I haven't tried it yet when combined without other changes; I will hopefully try it soon and I will report back (and un-WIP the PR).

Best regards,

Jakub