### PR TITLE
build: add support for local library installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ Thumbs.db
 .DS_Store
 *.o
 *.a
+*.pc

--- a/API/Makefile
+++ b/API/Makefile
@@ -1,8 +1,13 @@
 ## Copyright (c) 2015 Ahmad Fatoum
 CROSS_COMPILE ?= C:/CSLite/bin/arm-none-linux-gnueabi-
 PREFIX ?= $(CROSS_COMPILE)
+DESTDIR ?= $(CURDIR)
 CC = $(PREFIX)gcc
 AR = $(PREFIX)ar
+SED = sed
+MKDIR = mkdir -p
+INSTALL = cp
+RM = rm -rf
 SRCS = $(wildcard *.c)
 OBJS = $(patsubst %.c,%.o,$(SRCS))
 CFLAGS += -fno-strict-aliasing -fwrapv
@@ -15,6 +20,18 @@ libev3api.a: $(OBJS)
 %.o: %.c
 	$(CC) -Os $(CFLAGS) -isystem. -c $<
 
+libev3api.pc: libev3api.pc.in
+	$(SED) -e "s+@PREFIX@+$(DESTDIR)+" $< > $@
+
+install: libev3api.a libev3api.pc
+	$(MKDIR) $(DESTDIR)/lib $(DESTDIR)/share/pkgconfig $(DESTDIR)/include/ev3api
+	$(INSTALL) libev3api.a  $(DESTDIR)/lib/
+	$(INSTALL) *.h          $(DESTDIR)/include/ev3api/
+	$(INSTALL) libev3api.pc $(DESTDIR)/share/pkgconfig/
+
+uninstall:
+	$(RM) $(DESTDIR)/lib/libev3api.pc  $(DESTDIR)/share/pkgconfig/libev3api.pc $(DESTDIR)/include/ev3api
+
 example:
 	echo 'int main(void) { return EV3IsInitialized() == 1; }' | $(CC) -xc $(CFLAGS) - -L. -lev3api -I. -oexample -include ev3.h
 
@@ -22,6 +39,6 @@ example:
 #RM = del /Q
 #endif
 
-.PHONY: clean
+.PHONY: clean install uninstall
 clean:
 	$(RM) *.o *.a *.d example

--- a/API/libev3api.pc.in
+++ b/API/libev3api.pc.in
@@ -1,0 +1,10 @@
+prefix=@PREFIX@
+includedir=${prefix}/include/ev3api
+libdir=${prefix}/lib
+
+Name: EV3-API
+Description: EV3-API for Programming the LEGO Mindstorms EV3 in C
+URL: https://github.com/c4ev3/EV3-API
+Version: 1.0.0
+Cflags: -I${includedir}
+Libs: -L${libdir} -lev3api


### PR DESCRIPTION
This commits adds support for locally installing the built library.
This installs:
 - the built library to $(DESTDIR)/lib
 - the *.h files to $(DESTDIR)/include/ev3api
 - a generated libev3api.pc pkgconfig file to $(DESTDIR)/share/pkgconfig

I have tested this locally on my Ubuntu 18.04 installation. However it's likely that on Windows it won't work yet.