### PR TITLE
Fix LcdClean to make it reset the cursor position.

### DIFF
--- a/API/ev3_lcd.c
+++ b/API/ev3_lcd.c
@@ -705,6 +705,11 @@ bool LcdUpdate()
 	return true;
 }
 
+static short X0 = 0;
+static short Y0 = 0;
+static short CURSOR_X = 0;
+static short CURSOR_Y = 0;
+
 bool LcdClean()
 {
 	if (!LcdInitialized())
@@ -712,6 +717,7 @@ bool LcdClean()
 	LCDInstance.currentFont = FONTTYPE_NORMAL;
 	memset((void*)LCDInstance.pLcd, 0, LCD_BUFFER_SIZE);
 	LCDInstance.Dirty = true;
+	X0 = Y0 = CURSOR_X = CURSOR_Y = 0;
 	return true;
 }
 bool LcdScroll(short Y)
@@ -1711,20 +1717,18 @@ void LcdRefresh()
 
 /********************************************************************************************/
 /**
-* Print Text with Variables 
+* Print Text with Variables
 * author: Ahmad Fatoum
 *
 *
 */
 
-static short CURSOR_X = 0;
-static short CURSOR_Y = 0;
 
 #ifdef __GNUC__
 #define ___FORMAT(x,y) __attribute__ ((format (printf, x, y)))
 #define ___NONNULL(...) __attribute__((nonnull (##__VA_ARGS__)))
 #else
-#define ___FORMAT(x,y) 
+#define ___FORMAT(x,y)
 #endif
 
 int vasprintf(char **buf, const char *fmt, va_list _va)
@@ -1771,13 +1775,13 @@ bool LcdTextf(char Color, short X, short Y, const char *fmt, ...)
 #define TAB_SIZE 2
 int LcdPrintf(char color, const char *fmt, ...)
 {
-	static short X0 = 0;
-	static short Y0 = 0;
+	X0 = 0;
+	Y0 = 0;
 	static short indent = 0;
-    
+
     X0 = CURSOR_X;
     Y0 = CURSOR_Y;
-    
+
 	if (!LcdInitialized())
 		return -1;
 
@@ -1858,7 +1862,7 @@ int Ev3Println(const char *fmt, ...)
 	va_start(args, fmt);
 	vasprintf(&buffer2, fmt, args);
 	va_end(args);
-	
+
 	return Ev3Printf("%s\n", buffer2);
 }
 
@@ -1867,10 +1871,10 @@ int TermPrintf(const char *fmt, ...)
     static short X0 = 0;
 	static short Y0 = 0;
 	static short indent = 0;
-    
+
     X0 = CURSOR_X;
     Y0 = CURSOR_Y;
-    
+
 	if (!LcdInitialized())
 		return -1;
 
@@ -1930,7 +1934,7 @@ int TermPrintf(const char *fmt, ...)
 
     CURSOR_X = X0;
     CURSOR_Y = Y0;
-    
+
     return c - buf;
 }
 
@@ -1942,7 +1946,7 @@ int TermPrintln(const char *fmt, ...)
 	va_start(args, fmt);
 	vasprintf(&buffer2, fmt, args);
 	va_end(args);
-	
+
 	return TermPrintf("%s\n", buffer2);
 }
 

--- a/API/ev3_lcd.c
+++ b/API/ev3_lcd.c
@@ -705,8 +705,6 @@ bool LcdUpdate()
 	return true;
 }
 
-static short X0 = 0;
-static short Y0 = 0;
 static short CURSOR_X = 0;
 static short CURSOR_Y = 0;
 
@@ -717,7 +715,7 @@ bool LcdClean()
 	LCDInstance.currentFont = FONTTYPE_NORMAL;
 	memset((void*)LCDInstance.pLcd, 0, LCD_BUFFER_SIZE);
 	LCDInstance.Dirty = true;
-	X0 = Y0 = CURSOR_X = CURSOR_Y = 0;
+	CURSOR_X = CURSOR_Y = 0;
 	return true;
 }
 bool LcdScroll(short Y)
@@ -1775,12 +1773,7 @@ bool LcdTextf(char Color, short X, short Y, const char *fmt, ...)
 #define TAB_SIZE 2
 int LcdPrintf(char color, const char *fmt, ...)
 {
-	X0 = 0;
-	Y0 = 0;
 	static short indent = 0;
-
-    X0 = CURSOR_X;
-    Y0 = CURSOR_Y;
 
 	if (!LcdInitialized())
 		return -1;
@@ -1800,44 +1793,41 @@ int LcdPrintf(char color, const char *fmt, ...)
 	while (*c)
 	{
 		if (indent == TAB_SIZE) indent = 0;
-		if (! (0 <= X0 && X0 < LCD_WIDTH - width) )
+		if (! (0 <= CURSOR_X && CURSOR_X < LCD_WIDTH - width) )
 		{
-			Y0 += height + 2;
-			X0 = 0;
+			CURSOR_Y += height + 2;
+			CURSOR_X = 0;
 		}
 		switch (*c)
 		{
 			case '\n':
-				Y0 += height + 2;
+				CURSOR_Y += height + 2;
 				/* fall through */
 			case '\r':
-				X0 = 0;
+				CURSOR_X = 0;
 				break;
 			case '\b':
-				X0 -= width;
+				CURSOR_X -= width;
 				break;
 			case '\v':
-				Y0 += height + 2;
+				CURSOR_Y += height + 2;
 				break;
 			case '\f':
-				X0 = Y0 = 0;
+				CURSOR_X = CURSOR_Y = 0;
 				break;
 			case '\t':
-				X0 += width * (TAB_SIZE - indent);
+				CURSOR_X += width * (TAB_SIZE - indent);
 				break;
 			default:
 				indent++;
 				dLcdDrawChar(LCDInstance.pLcd, color, X0, Y0, LCDInstance.currentFont, *c);
-				X0 += width;
+				CURSOR_X += width;
 		}
 		indent++;
 		c++;
 	}
 	LCDInstance.Dirty = true;
-
-    CURSOR_X = X0;
-    CURSOR_Y = Y0;
-    return c - buf;
+  return c - buf;
 }
 
 int Ev3Printf(const char *fmt, ...)

--- a/API/ev3_lcd.c
+++ b/API/ev3_lcd.c
@@ -1820,7 +1820,7 @@ int LcdPrintf(char color, const char *fmt, ...)
 				break;
 			default:
 				indent++;
-				dLcdDrawChar(LCDInstance.pLcd, color, X0, Y0, LCDInstance.currentFont, *c);
+				dLcdDrawChar(LCDInstance.pLcd, color, CURSOR_X, CURSOR_Y, LCDInstance.currentFont, *c);
 				CURSOR_X += width;
 		}
 		indent++;


### PR DESCRIPTION
This PR fixes both issues #39 and #13. It doesn't break anything else, and it makes the API function LcdClean() reset the cursor position that is later used by LcdPrintf(). This fixes the bug that was messing with programs like this:
```C
#include <ev3.h>

int main() {
  InitEV3();

  LcdPrintf(1, "Hello World!\n");
  Wait(1000);
  LcdClean();
  LcdPrintf(1, "I am at the top of the screen, just where I belong.\n");
  Wait(2000);

  FreeEV3();
  return 0;
}
```