### PR TITLE
feature(lcd): add functions for manipulating text cursor

### DIFF
--- a/API/ev3_lcd.c
+++ b/API/ev3_lcd.c
@@ -1949,5 +1949,31 @@ int TermPrintln(const char *fmt, ...)
 void Ev3Clear()
 {
 	LcdClean();
-	LcdPrintf(1, "%s", "\f");
+	LcdResetCursor();
+}
+
+void LcdSetCursorX(short x)
+{
+	CURSOR_X = x;
+}
+
+void LcdSetCursorY(short y)
+{
+	CURSOR_Y = y;
+}
+
+short LcdGetCursorX(void)
+{
+	return CURSOR_X;
+}
+
+short LcdGetCursorY(void)
+{
+	return CURSOR_Y;
+}
+
+void LcdResetCursor(void)
+{
+	LcdSetCursorX(0);
+	LcdSetCursorY(0);
 }

--- a/API/ev3_lcd.h
+++ b/API/ev3_lcd.h
@@ -289,6 +289,65 @@ int TermPrintf(const char *fmt, ...);
  */
 int TermPrintln(const char *fmt, ...);
 
+/**
+ * \brief Set the X coordinate of the text cursor.
+ *
+ * This will overwrite the X (horizontal) pixel coordinate of the top left corner
+ * of the next character to be typed via Ev3Printf()/LcdPrintf()/... funtions.
+ *
+ * \param x Top left pixel X coordinate of the next character to be typed.
+ * \sa Ev3Printf(), Ev3Println(), Ev3Clear(), TermPrintf(), TermPrintln(), LcdPrintf()
+ * \sa LcdSetCursorY(), LcdGetCursorX(), LcdGetCursorY(), LcdResetCursor()
+ */
+void LcdSetCursorX(short x);
+
+/**
+ * \brief Set the Y coordinate of the text cursor.
+ *
+ * This will overwrite the Y (vertical) pixel coordinate of the top left corner
+ * of the next character to be typed via Ev3Printf()/LcdPrintf()/... funtions.
+ *
+ * \param y Top left pixel Y coordinate of the next character to be typed.
+ * \sa Ev3Printf(), Ev3Println(), Ev3Clear(), TermPrintf(), TermPrintln(), LcdPrintf()
+ * \sa LcdSetCursorX(), LcdGetCursorX(), LcdGetCursorY(), LcdResetCursor()
+ */
+void LcdSetCursorY(short y);
+
+/**
+ * \brief Get the X coordinate of the text cursor.
+ *
+ * This will acquire the X (horizontal) pixel coordinate of the top left corner
+ * of the next character to be typed via Ev3Printf()/LcdPrintf()/... funtions.
+ *
+ * \return Top left pixel X coordinate of the next character to be typed.
+ * \sa Ev3Printf(), Ev3Println(), Ev3Clear(), TermPrintf(), TermPrintln(), LcdPrintf()
+ * \sa LcdSetCursorX(), LcdSetCursorY(), LcdGetCursorY(), LcdResetCursor()
+ */
+short LcdGetCursorX(void);
+
+/**
+ * \brief Set the X coordinate of the text cursor.
+ *
+ * This will acquire the Y (vertical) pixel coordinate of the top left corner
+ * of the next character to be typed via Ev3Printf()/LcdPrintf()/... funtions.
+ *
+ * \return Top left pixel Y coordinate of the next character to be typed.
+ * \sa Ev3Printf(), Ev3Println(), Ev3Clear(), TermPrintf(), TermPrintln(), LcdPrintf()
+ * \sa LcdSetCursorX(), LcdSetCursorY(), LcdGetCursorX(), LcdResetCursor()
+ */
+short LcdGetCursorY(void);
+
+/**
+ * \brief Move the text cursor to the top left corner.
+ *
+ * This will set the cursor coordinates to (0, 0).
+ *
+ * \sa Ev3Printf(), Ev3Println(), Ev3Clear(), TermPrintf(), TermPrintln(), LcdPrintf()
+ * \sa LcdSetCursorX(), LcdSetCursorY(), LcdGetCursorX(), LcdGetCursorY()
+ */
+void LcdResetCursor(void);
+
+
 #endif // ev3_lcd_h
 
 #ifdef __cplusplus


### PR DESCRIPTION
This PR adds functions for setting and getting X and Y coordinates of the text cursor. This partially duplicates the functionality available in *Printf() functions; however the added convenience could be worth it. Also, the code in *Printf() functions accesses a cached local variable instead of the global one, so the code there would have to be modified not to cache the variable.

Relates to #39
Relates to #40 

Feel free to close this pull request if this change is superfluous.