### PR TITLE
Build with the C99 language revision

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,9 @@ INSTALL = cp
 RM = rm -rf
 SRCS = $(wildcard API/*.c contrib/**/*.c)
 OBJS = $(patsubst %.c,%.o,$(SRCS))
-CFLAGS += -fno-strict-aliasing -fwrapv
-CFLAGS += -Wall -Wextra -Wpointer-sign -Wno-unused-parameter
-CFLAGS += -D_GNU_SOURCE=1
+override CFLAGS += -fno-strict-aliasing -fwrapv
+override CFLAGS += -Wall -Wextra -Wpointer-sign -Wno-unused-parameter
+override CFLAGS += -D_GNU_SOURCE=1
 
 .DEFAULT: libev3api.a
 libev3api.a: $(OBJS)

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ INSTALL = cp
 RM = rm -rf
 SRCS = $(wildcard API/*.c contrib/**/*.c)
 OBJS = $(patsubst %.c,%.o,$(SRCS))
+override CFLAGS += -std=c99
 override CFLAGS += -fno-strict-aliasing -fwrapv
 override CFLAGS += -Wall -Wextra -Wpointer-sign -Wno-unused-parameter
 override CFLAGS += -D_GNU_SOURCE=1


### PR DESCRIPTION
Hi,

this PR is a spinoff from #35. The first commit fixes the problem that CFLAGS that are given on the command line weren't appended with the flags specified in the Makefile. The second commit then enables `-std=c99` for the library. This is likely not necessary for GCC 8, but it is needed for GCC 4.

Best regards,

Jakub