### PR TITLE
feature: add new module for resizable arrays

### DIFF
--- a/API/ev3.h
+++ b/API/ev3.h
@@ -51,6 +51,7 @@ extern "C" {
 #include "ev3_lcd.h"
 #include "ev3_sound.h"
 #include "ev3_bluetooth.h"
+#include "ev3_array.h"
 
 // Priority of the InitEV3/FreeEV3 functions for automatic construction and destruction
 // see https://gcc.gnu.org/onlinedocs/gcc-4.3.3/gcc/Function-Attributes.html

--- a/API/ev3_array.c
+++ b/API/ev3_array.c
@@ -1,0 +1,194 @@
+/** \file ev3_array.c
+ * \brief Implementation of resizable arrays
+ *
+ * License:
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/
+ *
+ * The Initial Developer of this code is Jakub Vanek.
+ * Portions created by Jakub Vanek are Copyright (C) 2020 Jakub Vanek.
+ * All Rights Reserved.
+ *
+ * ----------------------------------------------------------------------------
+ *
+ * \author Jakub Vanek (linuxtardis_at_gmail.com)
+ * \date 2020-03-03
+ * \version 1
+ */
+
+////////////////////////////////////////////////////////////////
+// INCLUDES
+
+#include "ev3_array.h"
+#include <string.h>
+
+////////////////////////////////////////////////////////////////
+// PRIVATE FUNCTIONS
+
+/*!
+ * \brief Round the given number up to a nearest 32bit power of two.
+ * \param v Number to round up.
+ * \return Rounded number.
+ * \remark see https://graphics.stanford.edu/~seander/bithacks.html#RoundUpPowerOf2
+ */
+static
+size_t roundUpToNearestPowerOfTwo(size_t v)
+{
+    v--;
+    v |= v >> 1;
+    v |= v >> 2;
+    v |= v >> 4;
+    v |= v >> 8;
+    v |= v >> 16;
+    v++;
+    return v;
+}
+
+
+////////////////////////////////////////////////////////////////
+// IMPLEMENTATION OF PUBLIC API
+
+bool CArrayInit(DynamicCArray *array, size_t elem_size, size_t elem_alignment, size_t initial_capacity)
+{
+    *array = DYNAMIC_CARRAY_INITIALIZER(elem_size, elem_alignment);
+
+    return CArrayEnsureCapacity(array, initial_capacity);
+}
+
+void CArrayFree(DynamicCArray *array)
+{
+    free(array->elements);
+    array->elements = NULL;
+    array->capacity = 0;
+    array->count = 0;
+}
+
+void *CArrayAccess(DynamicCArray *array, size_t index)
+{
+    if (index >= array->count)
+        return NULL;
+
+    return array->elements + (index * array->element_stride);
+}
+
+bool CArrayEnsureFreeCapacity(DynamicCArray *array, size_t minReserve)
+{
+    return CArrayEnsureCapacity(array, array->count + minReserve);
+}
+
+bool CArrayEnsureCapacity(DynamicCArray *array, size_t minCapacity)
+{
+    if (array->capacity < minCapacity)
+        return CArrayChangeCapacity(array, roundUpToNearestPowerOfTwo(minCapacity));
+    return true;
+}
+
+bool CArrayChangeCapacity(DynamicCArray *array, size_t newCapacity)
+{
+    if (newCapacity == 0)
+    {
+        CArrayFree(array);
+        return true;
+    }
+
+    size_t totalSize = array->element_stride * newCapacity;
+    void *memory = realloc(array->elements, totalSize);
+    if (memory == NULL)
+        return false;
+
+    array->elements = memory;
+    array->capacity = newCapacity;
+    if (array->count > array->capacity)
+        array->count = array->capacity;
+
+    return true;
+}
+
+void *CArrayStackPush(DynamicCArray *array)
+{
+    if (!CArrayEnsureFreeCapacity(array, 1))
+        return NULL;
+
+    array->count++;
+    return CArrayAccess(array, array->count - 1);
+}
+
+bool CArrayStackPop(DynamicCArray *array)
+{
+    if (array->count > 0)
+    {
+        array->count--;
+        return true;
+    }
+    return false;
+}
+
+void *CArrayInsert(DynamicCArray *array, size_t index, size_t count)
+{
+    if (index > array->count)
+        return NULL;
+
+    if (!CArrayEnsureFreeCapacity(array, count))
+        return NULL;
+
+    void *shiftPrev = array->elements + (index * array->element_stride);
+    void *shiftNext = shiftPrev + array->element_stride * count;
+    size_t shiftLen = array->count - index + count;
+
+    memmove(shiftNext, shiftPrev, shiftLen);
+
+    array->count += count;
+    return shiftPrev;
+}
+
+bool CArrayRemove(DynamicCArray *array, size_t index, size_t count)
+{
+    if (index + count - 1 >= array->count)
+        return false;
+
+    if (array->elements == NULL)
+        return false; // prevent UB in memmove
+
+    void *shiftNext = array->elements + (index * array->element_stride);
+    void *shiftPrev = shiftNext + array->element_stride * count;
+    size_t shiftLen = array->count - index;
+
+    memmove(shiftNext, shiftPrev, shiftLen);
+
+    array->count -= count;
+    return true;
+}
+
+bool CArrayMirror(DynamicCArray *destination, DynamicCArray *source)
+{
+    if (destination->element_stride != source->element_stride)
+        return false;
+
+    if (!CArrayEnsureCapacity(destination, source->count))
+        return false;
+
+    destination->count = source->count;
+
+    if (destination->count == 0)
+        return true;
+
+    if (destination->elements == NULL || source->elements == NULL)
+        return false; // prevent UB in memcpy
+
+    memcpy(destination->elements,
+           source->elements,
+           source->element_stride * destination->count);
+
+    return true;
+}

--- a/API/ev3_array.h
+++ b/API/ev3_array.h
@@ -1,0 +1,191 @@
+/** \file ev3_array.h
+ * \brief Dynamically-allocated resizable arrays
+ *
+ * License:
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/
+ *
+ * The Initial Developer of this code is Jakub Vanek.
+ * Portions created by Jakub Vanek are Copyright (C) 2020 Jakub Vanek.
+ * All Rights Reserved.
+ *
+ * ----------------------------------------------------------------------------
+ *
+ * \author Jakub Vanek (linuxtardis_at_gmail.com)
+ * \date 2020-03-03
+ * \version 1
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef ev3_array_h
+#define ev3_array_h
+
+////////////////////////////////////////////////////////////////
+// INCLUDES
+
+#include <stdlib.h>
+#include <stdbool.h>
+
+////////////////////////////////////////////////////////////////
+// MACROS
+
+/*!
+ * \brief Initialize an empty resizable array.
+ * \param size Size of each element (sizeof(x)).
+ * \param alignment Alignment requirement of each element (alignof(x)).
+ */
+#define DYNAMIC_CARRAY_INITIALIZER(size, alignment) \
+    ((DynamicCArray) {                             \
+        .elements = NULL,                         \
+        .count    =  0,                           \
+        .capacity =  0,                           \
+        .element_stride = (((size) + (alignment) - 1) / (alignment) * (alignment) ), \
+    })
+
+/*!
+ * \brief Initialize an empty resizable array suitable for storing values of the given type.
+ * \param type Type which will be stored in the array.
+ */
+#define DYNAMIC_CARRAY_INITIALIZER_FOR(type) DYNAMIC_CARRAY_INITIALIZER(sizeof(type), __alignof__(type))
+
+/*!
+ * \brief Iterate over all array elements (use just like a for cycle).
+ * \param name Name of the iteration variable.
+ * \param array CArray to iterate over.
+ */
+#define DYNAMIC_CARRAY_FOREACH(ptrname, array) \
+    for (void *ptrname = (array)->elements; \
+         (array)->elements != NULL && ptrname < (array)->elements + (array)->element_stride * (array)->count; \
+         ptrname += (array)->element_stride)
+
+////////////////////////////////////////////////////////////////
+// DATA STRUCTURES
+
+//! Simple resizable array.
+typedef struct
+{
+    //! Memory backing this array.
+    void *elements;
+    //! Number of active array elements, in element count.
+    size_t count;
+    //! Current capacity of the resizable array, in bytes (= size of elements).
+    size_t capacity;
+    //! CArray stride (i.e. how large the area occupied by one element is while keeping proper alignment)
+    size_t element_stride;
+} DynamicCArray;
+
+
+////////////////////////////////////////////////////////////////
+// PUBLIC FUNCTIONS
+
+/*!
+ * \brief Initialize and preallocate a resizable array.
+ * \param array Pointer to the array control structure.
+ * \param elem_size Size of each element, i.e. sizeof(type).
+ * \param elem_alignment Alignment requirement of each element, i.e. alignof(type)
+ * \param initial_capacity How many elements to preallocate.
+ * \return True if the allocation succeeded, false otherwise.
+ */
+bool CArrayInit(DynamicCArray *array, size_t elem_size, size_t elem_alignment, size_t initial_capacity);
+
+/*!
+ * \brief Deallocate memory of a given resizable array.
+ * \param array Pointer to the array control structure.
+ */
+void CArrayFree(DynamicCArray *array);
+
+/*!
+ * \brief Get a pointer to an array element.
+ * \param array Pointer to the array control structure.
+ * \param index Index of the element in the array.
+ * \return Pointer to the element or NULL if not in [0,size) range
+ */
+void *CArrayAccess(DynamicCArray *array, size_t index);
+
+/*!
+ * \brief Ensure that there will be at least given amount of free unused elements.
+ * \param array Pointer to the array control structure.
+ * \param minReserve Minimum number of free items.
+ * \return True if all allocations succeeded, false otherwise.
+ */
+bool CArrayEnsureFreeCapacity(DynamicCArray *array, size_t minReserve);
+
+/*!
+ * \brief Ensure that there will be at least given amount of elements.
+ * \param array Pointer to the array control structure.
+ * \param minCapacity Minimum capacity of the array.
+ * \return True if all allocations succeeded, false otherwise.
+ */
+bool CArrayEnsureCapacity(DynamicCArray *array, size_t minCapacity);
+
+/*!
+ * \brief Reallocate the array so that it has the specified capacity.
+ * \param array Pointer to the array control structure.
+ * \param newCapacity New capacity of the array.
+ * \return True if all allocations succeeded, false otherwise.
+ */
+bool CArrayChangeCapacity(DynamicCArray *array, size_t newCapacity);
+
+/*!
+ * \brief Insert an empty active element(s) into a given place.
+ * \param array Pointer to the array control structure.
+ * \param index Where to put the new element. Elements with index equal to or higher than this will be moved.
+ * \param count How many elements to insert.
+ * \return Pointer to the new element or NULL if an allocation failed or invalid arguments were provided.
+ */
+void *CArrayInsert(DynamicCArray *array, size_t index, size_t count);
+
+/*!
+ * \brief Remove a given active element(s) from the given array.
+ * \param array Pointer to the array control structure.
+ * \param index Where to remove the element from. Elements with index higher that this will be moved.
+ * \param count How many elements to remove.
+ * \return True if all arguments were valid, false otherwise.
+ */
+bool CArrayRemove(DynamicCArray *array, size_t index, size_t count);
+
+/*!
+ * \brief Add a new active empty element to the end of the array.
+ * \param array Pointer to the array control structure.
+ * \return Pointer to the new element or NULL if an allocation failed or invalid arguments were provided.
+ */
+void *CArrayStackPush(DynamicCArray *array);
+
+/*!
+ * \brief Remove the last active element from the array.
+ * \param array Pointer to the array control structure.
+ * @return True if it was possible to remove the element, false otherwise (there were already no elements).
+ */
+bool CArrayStackPop(DynamicCArray *array);
+
+/*!
+ * \brief Mirror data from one array to another.
+ *
+ * The destination array will be memory-independent from the source one.
+ * It will receive a new memory allocation instead of sharing it with the source.
+ * This way, it is necessary for example to perform locking only around this copy operation.
+ *
+ * \param destination Destination array.
+ * \param source Source array.
+ * \return Whether all allocations succeeded (true) or not (false).
+ */
+bool CArrayMirror(DynamicCArray *destination, DynamicCArray *source);
+
+#ifdef __cplusplus
+}
+#endif
+#endif // ev3_array_h


### PR DESCRIPTION
Hi,

This PR adds a relatively simple dynamically-allocated resizable array implementation. It was originally a part of the #35 PR; however now it is implemented as a separate module.

The features are mostly emulating basic C++'s `std::vector<>` which I'd have used if I could :smile: .

The container itself does not provide any locking, it is up to the caller to ensure that values and the control structure are not accessed simultaneously.

Best regards,

Jakub