### PR TITLE
add PlaySoundEx function to specify the volume of a sound

### DIFF
--- a/API/ev3_sound.c
+++ b/API/ev3_sound.c
@@ -615,7 +615,7 @@ void PlayToneEx(unsigned short frequency, unsigned short duration, uint8_t volum
 	WriteToSoundDevice(SoundData, sizeof(SoundData)); // write 6 bytes
 }
 
-void PlaySound(uint8_t aCode)
+void PlaySoundEx(uint8_t aCode, uint8_t volume)
 {
 	int i;
 	if (!SoundInitialized())
@@ -626,35 +626,35 @@ void PlaySound(uint8_t aCode)
 		return;
 
 	if (aCode == SOUND_CLICK)
-		PlayTone(600, MS_200);
+		PlayToneEx(600, MS_200, volume);
 	else if (aCode == SOUND_DOUBLE_BEEP)
 	{
-		PlayTone(600, MS_150);
+		PlayToneEx(600, MS_150, volume);
 		Wait(MS_200);
-		PlayTone(600, MS_150);
+		PlayToneEx(600, MS_150, volume);
 		Wait(MS_150);
 	}
 	else if (aCode == SOUND_UP)
 		for (i = 4; i < 8; i++)
 		{
-			PlayTone(TONE_C5 * i / 4, MS_100);
+			PlayToneEx(TONE_C5 * i / 4, MS_100, volume);
 			Wait(MS_100);
 		}
 	else if (aCode == SOUND_DOWN)
 		for (i = 7; i > 3; i--)
 		{
-			PlayTone(TONE_C5 * i / 4, MS_100);
+			PlayToneEx(TONE_C5 * i / 4, MS_100, volume);
 			Wait(MS_100);
 		}
 	else if (aCode == SOUND_LOW_BEEP)
 	{
-		PlayTone(100, MS_500);
+		PlayToneEx(100, MS_500, volume);
 		Wait(MS_500);
 	}
 	else if (aCode == SOUND_FAST_UP)
 		for (i = 4; i < 8; i++)
 		{
-			PlayTone(TONE_C5 * i / 4, MS_50);
+			PlayToneEx(TONE_C5 * i / 4, MS_50, volume);
 			Wait(MS_50);
 		}
 }

--- a/include/ev3_sound.h
+++ b/include/ev3_sound.h
@@ -71,6 +71,8 @@ void PlayToneEx(unsigned short frequency, unsigned short duration, uint8_t volum
 
 #define PlayTone(_f, _d) PlayToneEx((_f), (_d), 100)
 
+void PlaySoundEx(uint8_t aCode, uint8_t volume);
+
 /**
  * Play a system sound.
  * Play a sound that mimics the RCX system sounds using one of the
@@ -86,7 +88,7 @@ void PlayToneEx(unsigned short frequency, unsigned short duration, uint8_t volum
  * </TABLE>
  * \param aCode The system sound to play.  See \ref RCXSoundConstants.
  */
-void PlaySound(uint8_t aCode);
+#define PlaySound(aCode) PlaySoundEx((aCode), 100)
 
 /**
  * Play multiple tones.


### PR DESCRIPTION
Many of the functions inside `ev3_sound` allow to specify the value, but not `PlaySound`. This PR adds a function called `PlaySoundEX` that accepts the volume as a parameter, and substitutes the `PlaySound` function with a macro.